### PR TITLE
Update py-sc-client version to latest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-wheel
-tox
-pre-commit
-pytest
-py-sc-client>=0.2.1
-isort==5.10.1
-pylint==2.13.7
-black==22.3.0
+wheel==0.40.0
+tox==4.4.11
+pre-commit==3.2.2
+pytest==7.3.0
+py-sc-client==0.2.6
+isort==5.12.0
+pylint==2.17.2
+black==23.3.0

--- a/src/sc_kpm/utils/action_utils.py
+++ b/src/sc_kpm/utils/action_utils.py
@@ -55,8 +55,8 @@ def get_action_answer(action_node: ScAddr) -> ScAddr:
     templ = ScTemplate()
     templ.triple_with_relation(
         action_node,
-        [sc_types.EDGE_D_COMMON_VAR, ScAlias.RELATION_EDGE],
-        [sc_types.NODE_VAR_STRUCT, ScAlias.ELEMENT],
+        sc_types.EDGE_D_COMMON_VAR >> ScAlias.RELATION_EDGE,
+        sc_types.NODE_VAR_STRUCT >> ScAlias.ELEMENT,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
         ScKeynodes[CommonIdentifiers.NREL_ANSWER],
     )

--- a/src/sc_kpm/utils/common_utils.py
+++ b/src/sc_kpm/utils/common_utils.py
@@ -96,7 +96,7 @@ def get_system_idtf(addr: ScAddr) -> Idtf:
     templ.triple_with_relation(
         addr,
         sc_types.EDGE_D_COMMON_VAR,
-        [sc_types.LINK_VAR, ScAlias.LINK],
+        sc_types.LINK_VAR >> ScAlias.LINK,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
         nrel_system_idtf,
     )
@@ -110,8 +110,8 @@ def _search_relation_template(src: ScAddr, rel_node: ScAddr, rel_type: ScType) -
     template = ScTemplate()
     template.triple_with_relation(
         src,
-        [rel_type, ScAlias.ACCESS_EDGE],
-        [sc_types.UNKNOWN, ScAlias.ELEMENT],
+        rel_type >> ScAlias.ACCESS_EDGE,
+        sc_types.UNKNOWN >> ScAlias.ELEMENT,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
         rel_node,
     )

--- a/src/sc_kpm/utils/retrieve_utils.py
+++ b/src/sc_kpm/utils/retrieve_utils.py
@@ -19,7 +19,7 @@ def get_set_elements(set_node: ScAddr) -> List[ScAddr]:
     templ = ScTemplate()
     templ.triple(set_node, sc_types.EDGE_ACCESS_VAR_POS_PERM, sc_types.UNKNOWN)
     search_results = client.template_search(templ)
-    elements = [result.get(2) for result in search_results]
+    elements = [result[2] for result in search_results]
     elements.reverse()  # Elements are found in reverse order
     return elements
 
@@ -55,11 +55,11 @@ def _search_next_element_template(set_node: ScAddr, cur_element_edge: ScAddr) ->
     templ.triple_with_relation(
         cur_element_edge,
         sc_types.EDGE_D_COMMON_VAR,
-        [sc_types.EDGE_ACCESS_VAR_POS_PERM, ScAlias.ACCESS_EDGE],
+        sc_types.EDGE_ACCESS_VAR_POS_PERM >> ScAlias.ACCESS_EDGE,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
         ScKeynodes[CommonIdentifiers.NREL_BASIC_SEQUENCE],
     )
-    templ.triple(set_node, ScAlias.ACCESS_EDGE, [sc_types.UNKNOWN, ScAlias.ELEMENT])
+    templ.triple(set_node, ScAlias.ACCESS_EDGE, sc_types.UNKNOWN >> ScAlias.ELEMENT)
     return _get_first_search_template_result(templ)
 
 

--- a/tests/test_keynodes.py
+++ b/tests/test_keynodes.py
@@ -32,7 +32,7 @@ class KeynodesTests(BaseTestCase):
         ScKeynodes.resolve(idtf, sc_types.NODE_CONST)
         self.assertTrue(ScKeynodes.delete(idtf))
         self.assertFalse(ScKeynodes.get(idtf).is_valid())
-        self.assertRaises(InvalidValueError, ScKeynodes.__delitem__, idtf)
+        self.assertRaises(InvalidValueError, ScKeynodes.delete, idtf)
 
     def test_keynodes_initialization(self):
         self.assertRaises(TypeError, ScKeynodes)

--- a/tests/test_utils/test_creation_utils.py
+++ b/tests/test_utils/test_creation_utils.py
@@ -59,24 +59,25 @@ class TestGenerationUtils(BaseTestCase):
         template = _get_set_template(set_node, element1, element2)
         search_results = client.template_search(template)
         assert search_results
-        assert search_results[0].addrs[0].value == set_node.value
+        assert search_results[0][0] == set_node
 
 
 def _get_oriented_set_template(set_node: ScAddr, start_element: ScAddr, other_element: ScAddr) -> ScTemplate:
     rrel_one = ScKeynodes[CommonIdentifiers.RREL_ONE]
     nrel_sequence = ScKeynodes[CommonIdentifiers.NREL_BASIC_SEQUENCE]
 
+    edge1, edge2 = "edge1", "edge2"
     template = ScTemplate()
     template.triple_with_relation(
         set_node,
-        [sc_types.EDGE_ACCESS_VAR_POS_PERM, edge1 := "edge1"],
+        sc_types.EDGE_ACCESS_VAR_POS_PERM >> edge1,
         start_element,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
         rrel_one,
     )
     template.triple(
         set_node,
-        [sc_types.EDGE_ACCESS_VAR_POS_PERM, edge2 := "edge2"],
+        sc_types.EDGE_ACCESS_VAR_POS_PERM >> edge2,
         other_element,
     )
     template.triple_with_relation(
@@ -107,7 +108,7 @@ def _get_set_template(set_node: ScAddr, element1: ScAddr, element2: ScAddr) -> S
 def _get_structure_template(element1: ScAddr, element2: ScAddr) -> ScTemplate:
     template = ScTemplate()
     template.triple(
-        [sc_types.NODE_VAR_STRUCT, set_node := "_set_node"],
+        sc_types.NODE_VAR_STRUCT >> (set_node := "_set_node"),
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
         element1,
     )


### PR DESCRIPTION
## Changes

- Update requirements and change py-sc-client version 0.2.6
- Add reconnection logic
- Use py-sc-client syntactic sugar