### PR TITLE
feat: remove logic that copies py-sc-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,16 +238,20 @@ For creating edge between **src** and **trg** with setting its type use **create
 
 ```python
 def create_edge(edge_type: ScType, src: ScAddr, trg: ScAddr) -> ScAddr: ...
+
+def create_edges(edge_type: ScType, src: ScAddr, *targets: ScAddr) -> List[ScAddr]: ...
 ```
 
 ```python
 from sc_client.constants import sc_types
 from sc_kpm.utils import create_nodes
-from sc_kpm.utils import create_edge
+from sc_kpm.utils import create_edge, create_edges
 
-src, trg = create_nodes(*[sc_types.NODE_CONST] * 2)
-msg_edge = create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg)  # ScAddr(...)
-assert src.is_valid() and trg.is_valid() and msg_edge.is_valid()
+src, trg, trg2, trg3 = create_nodes(*[sc_types.NODE_CONST] * 4)
+edge = create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg)  # ScAddr(...)
+edges = create_edges(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg2, trg3)  # [ScAddr(...), ScAddr(...)]
+assert edge.is_valid()
+assert all(edges)
 ```
 
 Function **is_valid()** is used for validation addresses of nodes or edges.

--- a/README.md
+++ b/README.md
@@ -225,9 +225,11 @@ from sc_kpm import ScKeynodes
 from sc_kpm.utils.common_utils import create_node, create_nodes
 
 lang = create_node(sc_types.NODE_CONST_CLASS)  # ScAddr(...)
-lang_en = create_node(sc_types.NODE_CONST_CLASS, "lang_en")  # ScAddr(...)
-assert lang_en == ScKeynodes["lang_en"]
+lang_en = create_node(sc_types.NODE_CONST_CLASS)  # ScAddr(...)
+assert lang.is_valid() and lang_en.is_valid()
 elements = create_nodes(sc_types.NODE_CONST, sc_types.NODE_VAR)  # [ScAddr(...), ScAddr(...)]
+assert len(elements) == 2
+assert all(element.is_valid() for element in elements)
 ```
 
 ### Edges creating
@@ -304,20 +306,14 @@ from sc_kpm.utils import create_node, create_nodes
 from sc_kpm.utils import create_binary_relation, create_role_relation, create_norole_relation
 
 src, trg = create_nodes(*[sc_types.NODE_CONST] * 2)
-increase_relation = create_node(sc_types.NODE_CONST_CLASS, "increase")
+increase_relation = create_node(sc_types.NODE_CONST_CLASS)
 
 brel = create_binary_relation(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg, increase_relation)  # ScAddr(...)
 rrel = create_role_relation(src, trg, ScKeynodes[CommonIdentifiers.RREL_ONE])  # ScAddr(...)
-nrel = create_norole_relation(src, trg, create_node(sc_types.NODE_CONST_NOROLE, "connection"))  # ScAddr(...)
+nrel = create_norole_relation(src, trg, create_node(sc_types.NODE_CONST_NOROLE))  # ScAddr(...)
 ```
 
 ### Deleting utils
-
-If you want remove elements (nodes, edges) use function:
-
-```python
-def delete_elements(*addrs: ScAddr) -> bool: ...
-```
 
 If you want to remove all edges between two nodes, which define by their type use
 
@@ -325,15 +321,12 @@ If you want to remove all edges between two nodes, which define by their type us
 def delete_edges(source: ScAddr, target: ScAddr, *edge_types: ScType) -> bool: ...
 ```
 
-These two functions return **True** if operations was successful and **False** otherwise.
+It return **True** if operations was successful and **False** otherwise.
 
 ```python
 from sc_client.constants import sc_types
 from sc_kpm.utils import create_nodes, create_edge
-from sc_kpm.utils import delete_edges, delete_elements
-
-elements = create_nodes(*[sc_types.NODE_CONST] * 2)
-delete_elements(*elements)  # True
+from sc_kpm.utils import delete_edges
 
 src, trg = create_nodes(*[sc_types.NODE_CONST] * 2)
 edge = create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg)
@@ -406,10 +399,10 @@ def get_link_content(link: ScAddr) -> Union[str, int]: ...
 
 ```python
 from sc_kpm.utils import create_link
-from sc_kpm.utils import get_link_content
+from sc_kpm.utils import get_link_content_data
 
 water = create_link("water")
-content = get_link_content(water)  # "water"
+content = get_link_content_data(water)  # "water"
 ```
 
 ### Getting system identifier
@@ -426,7 +419,7 @@ from sc_kpm import ScKeynodes
 from sc_kpm.utils import create_node
 from sc_kpm.utils import get_system_idtf
 
-lang_en = create_node(sc_types.NODE_CONST_CLASS, "lang_en")  # ScAddr(...)
+lang_en = create_node(sc_types.NODE_CONST_CLASS)  # ScAddr(...)
 idtf = get_system_idtf(lang_en)  # "lang_en"
 assert ScKeynodes[idtf] == lang_en
 ```
@@ -594,7 +587,7 @@ from sc_kpm.utils.action_utils import check_action_class
 
 action_node = create_node(sc_types.NODE_CONST)
 create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, ScKeynodes[CommonIdentifiers.QUESTION], action_node)
-action_class = create_node(sc_types.NODE_CONST_CLASS, "some_classification")
+action_class = create_node(sc_types.NODE_CONST_CLASS)
 create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, action_class, action_node)
 
 assert check_action_class(action_class, action_node)

--- a/docs/examples/sum_agent.py
+++ b/docs/examples/sum_agent.py
@@ -12,7 +12,7 @@ from sc_client.constants.common import ScEventType
 from sc_client.models import ScAddr, ScLinkContentType
 
 from sc_kpm import ScAgent, ScModule, ScResult, ScServer
-from sc_kpm.utils import create_link, get_link_content
+from sc_kpm.utils import create_link, get_link_content_data
 from sc_kpm.utils.action_utils import (
     create_action_answer,
     execute_agent,
@@ -41,8 +41,8 @@ class SumAgent(ScAgent):
         arg1_link, arg2_link = get_action_arguments(action_node, 2)
         if not arg1_link or not arg2_link:
             return ScResult.ERROR_INVALID_PARAMS
-        arg1_content = get_link_content(arg1_link)
-        arg2_content = get_link_content(arg2_link)
+        arg1_content = get_link_content_data(arg1_link)
+        arg2_content = get_link_content_data(arg2_link)
         if not isinstance(arg1_content, int) or not isinstance(arg2_content, int):
             return ScResult.ERROR_INVALID_TYPE
         create_action_answer(action_node, create_link(arg1_content + arg2_content, ScLinkContentType.INT))
@@ -69,7 +69,7 @@ def main():
             assert is_successful
             answer_struct = get_action_answer(question)
             answer_link = get_set_elements(answer_struct)[0]
-            answer_content = get_link_content(answer_link)
+            answer_content = get_link_content_data(answer_link)
             logging.info("Answer received: %s", repr(answer_content))
 
 

--- a/docs/examples/sum_agent_classic.py
+++ b/docs/examples/sum_agent_classic.py
@@ -12,7 +12,7 @@ from sc_client.models import ScAddr, ScLinkContentType
 
 from sc_kpm import ScAgentClassic, ScModule, ScResult, ScServer
 from sc_kpm.identifiers import CommonIdentifiers
-from sc_kpm.utils import create_link, get_link_content
+from sc_kpm.utils import create_link, get_link_content_data
 from sc_kpm.utils.action_utils import (
     create_action_answer,
     execute_agent,
@@ -40,8 +40,8 @@ class SumAgentClassic(ScAgentClassic):
         arg1_link, arg2_link = get_action_arguments(action_node, 2)
         if not arg1_link or not arg2_link:
             return ScResult.ERROR_INVALID_PARAMS
-        arg1_content = get_link_content(arg1_link)
-        arg2_content = get_link_content(arg2_link)
+        arg1_content = get_link_content_data(arg1_link)
+        arg2_content = get_link_content_data(arg2_link)
         if not isinstance(arg1_content, int) or not isinstance(arg2_content, int):
             return ScResult.ERROR_INVALID_TYPE
         create_action_answer(action_node, create_link(arg1_content + arg2_content, ScLinkContentType.INT))
@@ -66,7 +66,7 @@ def main():
         assert is_successful
         answer_struct = get_action_answer(question)
         answer_link = get_set_elements(answer_struct)[0]
-        answer_content = get_link_content(answer_link)
+        answer_content = get_link_content_data(answer_link)
         logging.info("Answer received: %s", repr(answer_content))
 
 

--- a/src/sc_kpm/utils/__init__.py
+++ b/src/sc_kpm/utils/__init__.py
@@ -9,6 +9,7 @@ from sc_kpm.utils.common_utils import (
     check_edge,
     create_binary_relation,
     create_edge,
+    create_edges,
     create_link,
     create_links,
     create_node,

--- a/src/sc_kpm/utils/__init__.py
+++ b/src/sc_kpm/utils/__init__.py
@@ -16,12 +16,11 @@ from sc_kpm.utils.common_utils import (
     create_norole_relation,
     create_role_relation,
     delete_edges,
-    delete_elements,
     get_edge,
     get_edges,
     get_element_by_norole_relation,
     get_element_by_role_relation,
-    get_link_content,
+    get_link_content_data,
     get_system_idtf,
     search_role_relation_template,
 )

--- a/src/sc_kpm/utils/common_utils.py
+++ b/src/sc_kpm/utils/common_utils.py
@@ -10,6 +10,7 @@ from sc_client import client
 from sc_client.constants import sc_types
 from sc_client.constants.sc_types import ScType
 from sc_client.models import ScAddr, ScConstruction, ScLinkContent, ScLinkContentType, ScTemplate, ScTemplateResult
+from sc_client.models.sc_construction import ScLinkContentData
 
 from sc_kpm.identifiers import CommonIdentifiers, ScAlias
 from sc_kpm.sc_keynodes import Idtf, ScKeynodes
@@ -22,9 +23,7 @@ def create_nodes(*node_types: ScType) -> List[ScAddr]:
     return client.create_elements(construction)
 
 
-def create_node(node_type: ScType, sys_idtf: str = None) -> ScAddr:
-    if sys_idtf:
-        return ScKeynodes.resolve(sys_idtf, node_type)
+def create_node(node_type: ScType) -> ScAddr:
     return create_nodes(node_type)[0]
 
 
@@ -71,7 +70,12 @@ def create_norole_relation(src: ScAddr, trg: ScAddr, *nrel_nodes: ScAddr) -> ScA
 
 
 def check_edge(edge_type: ScType, source: ScAddr, target: ScAddr) -> bool:
-    return get_edge(source, target, edge_type).is_valid()
+    return bool(get_edges(source, target, edge_type))
+
+
+def get_edge(source: ScAddr, target: ScAddr, edge_type: ScType) -> ScAddr:
+    edges = get_edges(source, target, edge_type)
+    return edges[0] if edges else ScAddr(0)
 
 
 def get_edges(source: ScAddr, target: ScAddr, *edge_types: ScType) -> List[ScAddr]:
@@ -80,13 +84,8 @@ def get_edges(source: ScAddr, target: ScAddr, *edge_types: ScType) -> List[ScAdd
         templ = ScTemplate()
         templ.triple(source, edge_type, target)
         results = client.template_search(templ)
-        result_edges.extend([result.get(1) for result in results])
+        result_edges.extend(result.get(1) for result in results)
     return result_edges
-
-
-def get_edge(source: ScAddr, target: ScAddr, edge_type: ScType) -> ScAddr:
-    edges = get_edges(source, target, edge_type)
-    return edges[0] if edges else ScAddr(0)
 
 
 def get_system_idtf(addr: ScAddr) -> Idtf:
@@ -102,7 +101,7 @@ def get_system_idtf(addr: ScAddr) -> Idtf:
     )
     result = client.template_search(templ)
     if result:
-        return get_link_content(result[0].get(ScAlias.LINK))
+        return get_link_content_data(result[0].get(ScAlias.LINK))
     return ""
 
 
@@ -137,14 +136,10 @@ def get_element_by_norole_relation(src: ScAddr, nrel_node: ScAddr) -> ScAddr:
     return search_result.get(ScAlias.ELEMENT) if search_result else ScAddr(0)
 
 
-def get_link_content(link: ScAddr) -> Union[str, int]:
+def get_link_content_data(link: ScAddr) -> ScLinkContentData:
     content_part = client.get_link_content(link)
     return content_part[0].data
 
 
-def delete_elements(*addrs: ScAddr) -> bool:
-    return client.delete_elements(*addrs)
-
-
 def delete_edges(source: ScAddr, target: ScAddr, *edge_types: ScType) -> bool:
-    return delete_elements(*get_edges(source, target, *edge_types))
+    return client.delete_elements(*get_edges(source, target, *edge_types))

--- a/src/sc_kpm/utils/common_utils.py
+++ b/src/sc_kpm/utils/common_utils.py
@@ -48,9 +48,14 @@ def create_link(
 
 
 def create_edge(edge_type: ScType, src: ScAddr, trg: ScAddr) -> ScAddr:
+    return create_edges(edge_type, src, trg)[0]
+
+
+def create_edges(edge_type: ScType, src: ScAddr, *targets: ScAddr) -> List[ScAddr]:
     construction = ScConstruction()
-    construction.create_edge(edge_type, src, trg)
-    return client.create_elements(construction)[0]
+    for trg in targets:
+        construction.create_edge(edge_type, src, trg)
+    return client.create_elements(construction)
 
 
 def create_binary_relation(edge_type: ScType, src: ScAddr, trg: ScAddr, *relations: ScAddr) -> ScAddr:
@@ -84,7 +89,7 @@ def get_edges(source: ScAddr, target: ScAddr, *edge_types: ScType) -> List[ScAdd
         templ = ScTemplate()
         templ.triple(source, edge_type, target)
         results = client.template_search(templ)
-        result_edges.extend(result.get(1) for result in results)
+        result_edges.extend(result[1] for result in results)
     return result_edges
 
 

--- a/tests/test_utils/test_action_utils.py
+++ b/tests/test_utils/test_action_utils.py
@@ -4,6 +4,7 @@ Distributed under the MIT License
 (See an accompanying file LICENSE or a copy at https://opensource.org/licenses/MIT)
 """
 
+from sc_client.client import delete_elements
 from sc_client.constants import sc_types
 from sc_client.constants.common import ScEventType
 
@@ -11,7 +12,7 @@ from sc_kpm import ScAgent, ScKeynodes, ScModule
 from sc_kpm.identifiers import CommonIdentifiers
 from sc_kpm.sc_result import ScResult
 from sc_kpm.utils.action_utils import check_action_class, execute_agent, finish_action_with_status
-from sc_kpm.utils.common_utils import create_edge, create_node, delete_elements
+from sc_kpm.utils.common_utils import create_edge, create_node
 from tests.common_tests import BaseTestCase
 
 test_node_idtf = "test_node"
@@ -34,21 +35,21 @@ class ScModuleTest(ScModule):
 
 class TestActionUtils(BaseTestCase):
     def test_validate_action(self):
-        action_class = "test_action_class"
+        action_class_idtf = "test_action_class"
+        action_class_node = ScKeynodes.resolve(action_class_idtf, sc_types.NODE_CONST)
         question = ScKeynodes[CommonIdentifiers.QUESTION]
         test_node = create_node(sc_types.NODE_CONST)
-        action_class_node = create_node(sc_types.NODE_CONST, action_class)
-        assert check_action_class(action_class_node, test_node) is False
-        assert check_action_class(action_class, test_node) is False
+        self.assertFalse(check_action_class(action_class_node, test_node))
+        self.assertFalse(check_action_class(action_class_idtf, test_node))
         class_edge = create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, action_class_node, test_node)
-        assert check_action_class(action_class_node, test_node) is False
-        assert check_action_class(action_class, test_node) is False
+        self.assertFalse(check_action_class(action_class_node, test_node))
+        self.assertFalse(check_action_class(action_class_idtf, test_node))
         create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, question, test_node)
-        assert check_action_class(action_class_node, test_node)
-        assert check_action_class(action_class, test_node)
+        self.assertTrue(check_action_class(action_class_node, test_node))
+        self.assertTrue(check_action_class(action_class_idtf, test_node))
         delete_elements(class_edge)
-        assert check_action_class(action_class_node, test_node) is False
-        assert check_action_class(action_class, test_node) is False
+        self.assertFalse(check_action_class(action_class_node, test_node))
+        self.assertFalse(check_action_class(action_class_idtf, test_node))
 
     def test_call_agent(self):
         module = ScModuleTest()

--- a/tests/test_utils/test_common_utils.py
+++ b/tests/test_utils/test_common_utils.py
@@ -5,8 +5,10 @@ Distributed under the MIT License
 """
 
 from sc_client import client
+from sc_client.client import delete_elements
 from sc_client.constants import sc_types
 
+from sc_kpm import ScKeynodes
 from sc_kpm.utils.common_utils import (
     check_edge,
     create_binary_relation,
@@ -18,12 +20,11 @@ from sc_kpm.utils.common_utils import (
     create_norole_relation,
     create_role_relation,
     delete_edges,
-    delete_elements,
     get_edge,
     get_edges,
     get_element_by_norole_relation,
     get_element_by_role_relation,
-    get_link_content,
+    get_link_content_data,
     get_system_idtf,
 )
 from tests.common_tests import BaseTestCase
@@ -54,7 +55,7 @@ class TestActionUtils(BaseTestCase):
         link_content = "my link content"
         link = create_link(link_content)
         assert link.is_valid()
-        assert get_link_content(link) == link_content
+        assert get_link_content_data(link) == link_content
 
         link_counter = 10
         link_list = create_links(*[link_content for _ in range(link_counter)])
@@ -77,6 +78,12 @@ class TestActionUtils(BaseTestCase):
         assert same_edge.is_valid() and same_edge.value == edge.value
         assert check_edge(sc_types.EDGE_ACCESS_VAR_POS_PERM, source, target)
 
+        source, target, target2 = create_nodes(sc_types.NODE_CONST_CLASS, sc_types.NODE_CONST, sc_types.NODE_CONST)
+        edges = create_nodes(sc_types.EDGE_ACCESS_CONST_POS_PERM, source, target, target2)
+        assert all(edge_.is_valid() for edge_ in edges)
+        same_edges = get_edges(source, target, sc_types.EDGE_ACCESS_VAR_POS_PERM)
+        assert edges == same_edges
+
         edge_counter = 10
         for _ in range(edge_counter):
             create_edge(sc_types.EDGE_ACCESS_CONST_POS_PERM, source, target)
@@ -86,11 +93,9 @@ class TestActionUtils(BaseTestCase):
             assert edge.is_valid()
 
     def test_relation_utils(self):
-        rrel_idtf = "rrel_test"
-        nrel_idtf = "nrel_test"
         src, rrel_trg, nrel_trg = create_nodes(sc_types.NODE_CONST, sc_types.NODE_CONST, sc_types.NODE_CONST)
-        rrel_node = create_node(sc_types.NODE_CONST_ROLE, rrel_idtf)
-        nrel_node = create_node(sc_types.NODE_CONST_NOROLE, nrel_idtf)
+        rrel_node = create_node(sc_types.NODE_CONST_ROLE)
+        nrel_node = create_node(sc_types.NODE_CONST_NOROLE)
 
         rrel_edge_1 = create_binary_relation(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, rrel_trg, rrel_node)
         rrel_edge_2 = create_role_relation(src, rrel_trg, rrel_node)
@@ -119,8 +124,8 @@ class TestActionUtils(BaseTestCase):
         assert expected_empty.is_valid() is False
 
     def test_get_system_idtf(self):
-        test_idtf = "test_identifier"
-        test_node = create_node(sc_types.NODE_CONST_ROLE, test_idtf)
+        test_idtf = "rrel_1"
+        test_node = ScKeynodes[test_idtf]
         assert get_system_idtf(test_node) == test_idtf
 
     def test_deletion_utils(self):

--- a/tests/test_utils/test_common_utils.py
+++ b/tests/test_utils/test_common_utils.py
@@ -13,6 +13,7 @@ from sc_kpm.utils.common_utils import (
     check_edge,
     create_binary_relation,
     create_edge,
+    create_edges,
     create_link,
     create_links,
     create_node,
@@ -79,10 +80,11 @@ class TestActionUtils(BaseTestCase):
         assert check_edge(sc_types.EDGE_ACCESS_VAR_POS_PERM, source, target)
 
         source, target, target2 = create_nodes(sc_types.NODE_CONST_CLASS, sc_types.NODE_CONST, sc_types.NODE_CONST)
-        edges = create_nodes(sc_types.EDGE_ACCESS_CONST_POS_PERM, source, target, target2)
+        edges = create_edges(sc_types.EDGE_ACCESS_CONST_POS_PERM, source, target, target2)
         assert all(edge_.is_valid() for edge_ in edges)
-        same_edges = get_edges(source, target, sc_types.EDGE_ACCESS_VAR_POS_PERM)
-        assert edges == same_edges
+        same_target1 = get_edge(source, target, sc_types.EDGE_ACCESS_VAR_POS_PERM)
+        same_target2 = get_edge(source, target2, sc_types.EDGE_ACCESS_VAR_POS_PERM)
+        assert edges == [same_target1, same_target2]
 
         edge_counter = 10
         for _ in range(edge_counter):


### PR DESCRIPTION
## Changes

- `create_node()` can no longer create a node with an identifier. Use `ScKeynodes`
- `get_link_content` is renamed to `get_link_content_data` due to name match with `py-sc-client`
- `delete_elements` removed from `kpm` this is a copy from `client`
- Tests
