### PR TITLE
ScKeynodes.rrel(index: int)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ ScKeynodes.delete("identifier_to_delete")  # Delete keynode from kb and ScKeynod
 
 # Get rrel node
 ScKeynodes.rrel(1)  # Returns valid ScAddr of 'rrel_1'
+ScKeynodes.rrel(11)  # Raises KeyError if index more than ScKeynodes.max_rrel_index (default 10)
 ```
 
 ### ScAgent and ScAgentClassic

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ ScKeynodes.resolve("some_node", None)  # Returns the element if it exists, other
 
 # Delete identifier
 ScKeynodes.delete("identifier_to_delete")  # Delete keynode from kb and ScKeynodes cache
+
+# Get rrel node
+ScKeynodes.rrel(1)  # Returns valid ScAddr of 'rrel_1'
 ```
 
 ### ScAgent and ScAgentClassic
@@ -305,7 +308,6 @@ def create_norole_relation(src: ScAddr, trg: ScAddr, *nrel_nodes: ScAddr) -> ScA
 ```python
 from sc_client.constants import sc_types
 from sc_kpm import ScKeynodes
-from sc_kpm.identifiers import CommonIdentifiers
 from sc_kpm.utils import create_node, create_nodes
 from sc_kpm.utils import create_binary_relation, create_role_relation, create_norole_relation
 
@@ -313,7 +315,7 @@ src, trg = create_nodes(*[sc_types.NODE_CONST] * 2)
 increase_relation = create_node(sc_types.NODE_CONST_CLASS)
 
 brel = create_binary_relation(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg, increase_relation)  # ScAddr(...)
-rrel = create_role_relation(src, trg, ScKeynodes[CommonIdentifiers.RREL_ONE])  # ScAddr(...)
+rrel = create_role_relation(src, trg, ScKeynodes.rrel(1))  # ScAddr(...)
 nrel = create_norole_relation(src, trg, create_node(sc_types.NODE_CONST_NOROLE))  # ScAddr(...)
 ```
 
@@ -384,10 +386,10 @@ from sc_kpm.utils import create_nodes, create_role_relation, create_norole_relat
 from sc_kpm.utils import get_element_by_role_relation, get_element_by_norole_relation
 
 src, trg_rrel, trg_nrel = create_nodes(*[sc_types.NODE_CONST] * 3)
-rrel = create_role_relation(src, trg_rrel, ScKeynodes[CommonIdentifiers.RREL_ONE])  # ScAddr(...)
+rrel = create_role_relation(src, trg_rrel, ScKeynodes.rrel(1))  # ScAddr(...)
 nrel = create_norole_relation(src, trg_nrel, ScKeynodes[CommonIdentifiers.NREL_SYSTEM_IDENTIFIER])  # ScAddr(...)
 
-result_rrel = get_element_by_role_relation(src, ScKeynodes[CommonIdentifiers.RREL_ONE])  # ScAddr(...)
+result_rrel = get_element_by_role_relation(src, ScKeynodes.rrel(1))  # ScAddr(...)
 assert result_rrel == trg_rrel
 result_nrel = get_element_by_norole_relation(src, ScKeynodes[CommonIdentifiers.NREL_SYSTEM_IDENTIFIER])  # ScAddr(...)
 assert result_nrel == trg_nrel
@@ -620,12 +622,12 @@ action_node = create_node(sc_types.NODE_CONST)
 
 # Static argument
 argument1 = create_node(sc_types.NODE_CONST)
-create_role_relation(action_node, argument1, ScKeynodes[CommonIdentifiers.RREL_ONE])
+create_role_relation(action_node, argument1, ScKeynodes.rrel(1))
 
 # Dynamic argument
 dynamic_node = create_node(sc_types.NODE_CONST)
 rrel_dynamic_arg = ScKeynodes[CommonIdentifiers.RREL_DYNAMIC_ARGUMENT]
-create_role_relation(action_node, dynamic_node, rrel_dynamic_arg, ScKeynodes[CommonIdentifiers.RREL_TWO])
+create_role_relation(action_node, dynamic_node, rrel_dynamic_arg, ScKeynodes.rrel(2))
 argument2 = create_node(sc_types.NODE_CONST)
 create_edge(sc_types.EDGE_ACCESS_CONST_POS_TEMP, dynamic_node, argument2)
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ ScKeynodes.resolve("some_node", None)  # Returns the element if it exists, other
 ScKeynodes.delete("identifier_to_delete")  # Delete keynode from kb and ScKeynodes cache
 
 # Get rrel node
-ScKeynodes.rrel(1)  # Returns valid ScAddr of 'rrel_1'
-ScKeynodes.rrel(11)  # Raises KeyError if index more than 10
+ScKeynodes.rrel_index(1)  # Returns valid ScAddr of 'rrel_1'
+ScKeynodes.rrel_index(11)  # Raises KeyError if index more than 10
+ScKeynodes.rrel_index("some_str")  # Raises TypeError if index is not int
 ```
 
 ### ScAgent and ScAgentClassic
@@ -316,7 +317,7 @@ src, trg = create_nodes(*[sc_types.NODE_CONST] * 2)
 increase_relation = create_node(sc_types.NODE_CONST_CLASS)
 
 brel = create_binary_relation(sc_types.EDGE_ACCESS_CONST_POS_PERM, src, trg, increase_relation)  # ScAddr(...)
-rrel = create_role_relation(src, trg, ScKeynodes.rrel(1))  # ScAddr(...)
+rrel = create_role_relation(src, trg, ScKeynodes.rrel_index(1))  # ScAddr(...)
 nrel = create_norole_relation(src, trg, create_node(sc_types.NODE_CONST_NOROLE))  # ScAddr(...)
 ```
 
@@ -387,10 +388,10 @@ from sc_kpm.utils import create_nodes, create_role_relation, create_norole_relat
 from sc_kpm.utils import get_element_by_role_relation, get_element_by_norole_relation
 
 src, trg_rrel, trg_nrel = create_nodes(*[sc_types.NODE_CONST] * 3)
-rrel = create_role_relation(src, trg_rrel, ScKeynodes.rrel(1))  # ScAddr(...)
+rrel = create_role_relation(src, trg_rrel, ScKeynodes.rrel_index(1))  # ScAddr(...)
 nrel = create_norole_relation(src, trg_nrel, ScKeynodes[CommonIdentifiers.NREL_SYSTEM_IDENTIFIER])  # ScAddr(...)
 
-result_rrel = get_element_by_role_relation(src, ScKeynodes.rrel(1))  # ScAddr(...)
+result_rrel = get_element_by_role_relation(src, ScKeynodes.rrel_index(1))  # ScAddr(...)
 assert result_rrel == trg_rrel
 result_nrel = get_element_by_norole_relation(src, ScKeynodes[CommonIdentifiers.NREL_SYSTEM_IDENTIFIER])  # ScAddr(...)
 assert result_nrel == trg_nrel
@@ -623,12 +624,12 @@ action_node = create_node(sc_types.NODE_CONST)
 
 # Static argument
 argument1 = create_node(sc_types.NODE_CONST)
-create_role_relation(action_node, argument1, ScKeynodes.rrel(1))
+create_role_relation(action_node, argument1, ScKeynodes.rrel_index(1))
 
 # Dynamic argument
 dynamic_node = create_node(sc_types.NODE_CONST)
 rrel_dynamic_arg = ScKeynodes[CommonIdentifiers.RREL_DYNAMIC_ARGUMENT]
-create_role_relation(action_node, dynamic_node, rrel_dynamic_arg, ScKeynodes.rrel(2))
+create_role_relation(action_node, dynamic_node, rrel_dynamic_arg, ScKeynodes.rrel_index(2))
 argument2 = create_node(sc_types.NODE_CONST)
 create_edge(sc_types.EDGE_ACCESS_CONST_POS_TEMP, dynamic_node, argument2)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ScKeynodes.delete("identifier_to_delete")  # Delete keynode from kb and ScKeynod
 
 # Get rrel node
 ScKeynodes.rrel(1)  # Returns valid ScAddr of 'rrel_1'
-ScKeynodes.rrel(11)  # Raises KeyError if index more than ScKeynodes.max_rrel_index (default 10)
+ScKeynodes.rrel(11)  # Raises KeyError if index more than 10
 ```
 
 ### ScAgent and ScAgentClassic

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - README and LICENSE files
-- ScKeynodes class for caching identifiers and ScAddr objects
+- ScKeynodes class for caching identifiers and ScAddr objects. Easy access to rrel keynodes
 - ScAgent class for handling a single ScEvent
 - ScModule class for handling a multiple ScAgent
 - ScServer class for modules serving

--- a/src/sc_kpm/sc_keynodes.py
+++ b/src/sc_kpm/sc_keynodes.py
@@ -57,8 +57,10 @@ class ScKeynodesMeta(type):
             cls._logger.debug("Resolved %s identifier with type %s: %s", repr(identifier), repr(sc_type), repr(addr))
         return addr
 
-    def rrel(cls, index: int) -> ScAddr:
+    def rrel_index(cls, index: int) -> ScAddr:
         """Get rrel_i node. Max rrel index is 10"""
+        if not isinstance(index, int):
+            raise TypeError("Index of rrel node must be int")
         if index > cls._max_rrel_index:
             raise KeyError(f"You cannot use rrel more than {cls._max_rrel_index}")
         return cls.resolve(f"rrel_{index}", NODE_CONST_ROLE)  # pylint: disable=no-value-for-parameter

--- a/src/sc_kpm/sc_keynodes.py
+++ b/src/sc_kpm/sc_keynodes.py
@@ -23,6 +23,7 @@ class ScKeynodesMeta(type):
         super().__init__(*args, **kwargs)
         cls._dict: Dict[Idtf, ScAddr] = {}
         cls._logger: Logger = getLogger(f"{__name__}.{cls.__name__}")
+        cls.max_rrel_index: int = 10
 
     def __call__(cls, *args, **kwargs) -> None:
         raise TypeError(f"Use {cls.__name__} without initialization")
@@ -58,6 +59,8 @@ class ScKeynodesMeta(type):
 
     def rrel(cls, index: int) -> ScAddr:
         """Get rrel_i node"""
+        if index > cls.max_rrel_index:
+            raise KeyError(f"You cannot use rrel more than {cls.max_rrel_index}")
         return cls.resolve(f"rrel_{index}", NODE_CONST_ROLE)  # pylint: disable=no-value-for-parameter
 
 

--- a/src/sc_kpm/sc_keynodes.py
+++ b/src/sc_kpm/sc_keynodes.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional
 from sc_client import client
 from sc_client.client import delete_elements
 from sc_client.constants.exceptions import InvalidValueError
-from sc_client.constants.sc_types import ScType
+from sc_client.constants.sc_types import NODE_CONST_ROLE, ScType
 from sc_client.models import ScAddr, ScIdtfResolveParams
 
 Idtf = str
@@ -55,6 +55,10 @@ class ScKeynodesMeta(type):
                 cls._dict[identifier] = addr
             cls._logger.debug("Resolved %s identifier with type %s: %s", repr(identifier), repr(sc_type), repr(addr))
         return addr
+
+    def rrel(cls, index: int) -> ScAddr:
+        """Get rrel_i node"""
+        return cls.resolve(f"rrel_{index}", NODE_CONST_ROLE)  # pylint: disable=no-value-for-parameter
 
 
 class ScKeynodes(metaclass=ScKeynodesMeta):

--- a/src/sc_kpm/sc_keynodes.py
+++ b/src/sc_kpm/sc_keynodes.py
@@ -23,7 +23,7 @@ class ScKeynodesMeta(type):
         super().__init__(*args, **kwargs)
         cls._dict: Dict[Idtf, ScAddr] = {}
         cls._logger: Logger = getLogger(f"{__name__}.{cls.__name__}")
-        cls.max_rrel_index: int = 10
+        cls._max_rrel_index: int = 10
 
     def __call__(cls, *args, **kwargs) -> None:
         raise TypeError(f"Use {cls.__name__} without initialization")
@@ -58,9 +58,9 @@ class ScKeynodesMeta(type):
         return addr
 
     def rrel(cls, index: int) -> ScAddr:
-        """Get rrel_i node"""
-        if index > cls.max_rrel_index:
-            raise KeyError(f"You cannot use rrel more than {cls.max_rrel_index}")
+        """Get rrel_i node. Max rrel index is 10"""
+        if index > cls._max_rrel_index:
+            raise KeyError(f"You cannot use rrel more than {cls._max_rrel_index}")
         return cls.resolve(f"rrel_{index}", NODE_CONST_ROLE)  # pylint: disable=no-value-for-parameter
 
 

--- a/src/sc_kpm/utils/action_utils.py
+++ b/src/sc_kpm/utils/action_utils.py
@@ -40,7 +40,7 @@ def check_action_class(action_class: Union[ScAddr, Idtf], action_node: ScAddr) -
 def get_action_arguments(action_node: ScAddr, count: int) -> List[ScAddr]:
     arguments = []
     for index in range(1, count + 1):
-        argument = get_element_by_role_relation(action_node, ScKeynodes.rrel(index))
+        argument = get_element_by_role_relation(action_node, ScKeynodes.rrel_index(index))
         arguments.append(argument)
     return arguments
 
@@ -97,7 +97,7 @@ def _create_action_with_arguments(arguments: Dict[ScAddr, IsDynamic], concepts: 
     argument: ScAddr
     for index, (argument, is_dynamic) in enumerate(arguments.items(), 1):
         if argument.is_valid():
-            rrel_i = ScKeynodes.rrel(index)
+            rrel_i = ScKeynodes.rrel_index(index)
             if is_dynamic:
                 dynamic_node = create_node(sc_types.NODE_CONST)
                 create_role_relation(action_node, dynamic_node, rrel_dynamic_arg, rrel_i)

--- a/src/sc_kpm/utils/action_utils.py
+++ b/src/sc_kpm/utils/action_utils.py
@@ -40,8 +40,7 @@ def check_action_class(action_class: Union[ScAddr, Idtf], action_node: ScAddr) -
 def get_action_arguments(action_node: ScAddr, count: int) -> List[ScAddr]:
     arguments = []
     for index in range(1, count + 1):
-        rrel_i = ScKeynodes[f"rrel_{index}"]
-        argument = get_element_by_role_relation(action_node, rrel_i)
+        argument = get_element_by_role_relation(action_node, ScKeynodes.rrel(index))
         arguments.append(argument)
     return arguments
 
@@ -98,7 +97,7 @@ def _create_action_with_arguments(arguments: Dict[ScAddr, IsDynamic], concepts: 
     argument: ScAddr
     for index, (argument, is_dynamic) in enumerate(arguments.items(), 1):
         if argument.is_valid():
-            rrel_i = ScKeynodes[f"rrel_{index}"]
+            rrel_i = ScKeynodes.rrel(index)
             if is_dynamic:
                 dynamic_node = create_node(sc_types.NODE_CONST)
                 create_role_relation(action_node, dynamic_node, rrel_dynamic_arg, rrel_i)

--- a/src/sc_kpm/utils/creation_utils.py
+++ b/src/sc_kpm/utils/creation_utils.py
@@ -14,7 +14,7 @@ from sc_kpm.utils.common_utils import create_edge, create_node, create_norole_re
 
 
 def wrap_in_oriented_set(set_node: ScAddr, start_element: ScAddr, *elements: ScAddr) -> None:
-    rrel_one = ScKeynodes.rrel(1)
+    rrel_one = ScKeynodes.rrel_index(1)
     nrel_sequence = ScKeynodes[CommonIdentifiers.NREL_BASIC_SEQUENCE]
     curr_edge = create_role_relation(set_node, start_element, rrel_one)
     for next_element in elements:

--- a/src/sc_kpm/utils/creation_utils.py
+++ b/src/sc_kpm/utils/creation_utils.py
@@ -14,7 +14,7 @@ from sc_kpm.utils.common_utils import create_edge, create_node, create_norole_re
 
 
 def wrap_in_oriented_set(set_node: ScAddr, start_element: ScAddr, *elements: ScAddr) -> None:
-    rrel_one = ScKeynodes[CommonIdentifiers.RREL_ONE]
+    rrel_one = ScKeynodes.rrel(1)
     nrel_sequence = ScKeynodes[CommonIdentifiers.NREL_BASIC_SEQUENCE]
     curr_edge = create_role_relation(set_node, start_element, rrel_one)
     for next_element in elements:

--- a/src/sc_kpm/utils/retrieve_utils.py
+++ b/src/sc_kpm/utils/retrieve_utils.py
@@ -43,7 +43,7 @@ def _get_next_element(set_node: ScAddr, elements: List[ScAddr], access_edge: ScA
     if access_edge:
         elem_search_result = _search_next_element_template(set_node, access_edge)
     else:
-        elem_search_result = search_role_relation_template(set_node, ScKeynodes.rrel(1))
+        elem_search_result = search_role_relation_template(set_node, ScKeynodes.rrel_index(1))
     if elem_search_result is None:
         return None
     elements.append(elem_search_result.get(ScAlias.ELEMENT))

--- a/src/sc_kpm/utils/retrieve_utils.py
+++ b/src/sc_kpm/utils/retrieve_utils.py
@@ -43,7 +43,7 @@ def _get_next_element(set_node: ScAddr, elements: List[ScAddr], access_edge: ScA
     if access_edge:
         elem_search_result = _search_next_element_template(set_node, access_edge)
     else:
-        elem_search_result = search_role_relation_template(set_node, ScKeynodes[CommonIdentifiers.RREL_ONE])
+        elem_search_result = search_role_relation_template(set_node, ScKeynodes.rrel(1))
     if elem_search_result is None:
         return None
     elements.append(elem_search_result.get(ScAlias.ELEMENT))

--- a/tests/test_keynodes.py
+++ b/tests/test_keynodes.py
@@ -43,6 +43,4 @@ class KeynodesTests(BaseTestCase):
         self.assertTrue(check_elements(rrel_1)[0].is_role())
 
     def test_large_rrel(self):
-        self.assertRaises(KeyError, ScKeynodes.rrel, ScKeynodes.max_rrel_index + 1)
-        ScKeynodes.max_rrel_index += 1
-        self.assertTrue(ScKeynodes.rrel(11).is_valid())
+        self.assertRaises(KeyError, ScKeynodes.rrel, ScKeynodes._max_rrel_index + 1)

--- a/tests/test_keynodes.py
+++ b/tests/test_keynodes.py
@@ -1,6 +1,6 @@
 from common_tests import BaseTestCase
 from sc_client import client
-from sc_client.client import delete_elements
+from sc_client.client import check_elements, delete_elements
 from sc_client.constants import sc_types
 from sc_client.constants.exceptions import InvalidValueError
 from sc_client.models import ScAddr, ScIdtfResolveParams
@@ -36,3 +36,10 @@ class KeynodesTests(BaseTestCase):
 
     def test_keynodes_initialization(self):
         self.assertRaises(TypeError, ScKeynodes)
+
+    def test_rrel(self):
+        rrel_1 = ScKeynodes["rrel_1"]
+        self.assertEqual(ScKeynodes.rrel(1), rrel_1)
+        rrel_21 = ScKeynodes.rrel(21)
+        self.assertTrue(rrel_21.is_valid())
+        self.assertTrue(check_elements(rrel_21)[0].is_role())

--- a/tests/test_keynodes.py
+++ b/tests/test_keynodes.py
@@ -38,9 +38,12 @@ class KeynodesTests(BaseTestCase):
         self.assertRaises(TypeError, ScKeynodes)
 
     def test_rrel(self):
-        rrel_1 = ScKeynodes.rrel(1)
+        rrel_1 = ScKeynodes.rrel_index(1)
         self.assertTrue(rrel_1.is_valid())
         self.assertTrue(check_elements(rrel_1)[0].is_role())
 
     def test_large_rrel(self):
-        self.assertRaises(KeyError, ScKeynodes.rrel, ScKeynodes._max_rrel_index + 1)
+        self.assertRaises(KeyError, ScKeynodes.rrel_index, ScKeynodes._max_rrel_index + 1)
+
+    def test_wrong_rrel(self):
+        self.assertRaises(TypeError, ScKeynodes.rrel_index, "str")

--- a/tests/test_keynodes.py
+++ b/tests/test_keynodes.py
@@ -38,8 +38,11 @@ class KeynodesTests(BaseTestCase):
         self.assertRaises(TypeError, ScKeynodes)
 
     def test_rrel(self):
-        rrel_1 = ScKeynodes["rrel_1"]
-        self.assertEqual(ScKeynodes.rrel(1), rrel_1)
-        rrel_21 = ScKeynodes.rrel(21)
-        self.assertTrue(rrel_21.is_valid())
-        self.assertTrue(check_elements(rrel_21)[0].is_role())
+        rrel_1 = ScKeynodes.rrel(1)
+        self.assertTrue(rrel_1.is_valid())
+        self.assertTrue(check_elements(rrel_1)[0].is_role())
+
+    def test_large_rrel(self):
+        self.assertRaises(KeyError, ScKeynodes.rrel, ScKeynodes.max_rrel_index + 1)
+        ScKeynodes.max_rrel_index += 1
+        self.assertTrue(ScKeynodes.rrel(11).is_valid())

--- a/tests/test_utils/test_creation_utils.py
+++ b/tests/test_utils/test_creation_utils.py
@@ -63,9 +63,6 @@ class TestGenerationUtils(BaseTestCase):
 
 
 def _get_oriented_set_template(set_node: ScAddr, start_element: ScAddr, other_element: ScAddr) -> ScTemplate:
-    rrel_one = ScKeynodes[CommonIdentifiers.RREL_ONE]
-    nrel_sequence = ScKeynodes[CommonIdentifiers.NREL_BASIC_SEQUENCE]
-
     edge1, edge2 = "edge1", "edge2"
     template = ScTemplate()
     template.triple_with_relation(
@@ -73,7 +70,7 @@ def _get_oriented_set_template(set_node: ScAddr, start_element: ScAddr, other_el
         sc_types.EDGE_ACCESS_VAR_POS_PERM >> edge1,
         start_element,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
-        rrel_one,
+        ScKeynodes.rrel(1),
     )
     template.triple(
         set_node,
@@ -85,7 +82,7 @@ def _get_oriented_set_template(set_node: ScAddr, start_element: ScAddr, other_el
         sc_types.EDGE_D_COMMON_VAR,
         edge2,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
-        nrel_sequence,
+        ScKeynodes[CommonIdentifiers.NREL_BASIC_SEQUENCE],
     )
     return template
 

--- a/tests/test_utils/test_creation_utils.py
+++ b/tests/test_utils/test_creation_utils.py
@@ -70,7 +70,7 @@ def _get_oriented_set_template(set_node: ScAddr, start_element: ScAddr, other_el
         sc_types.EDGE_ACCESS_VAR_POS_PERM >> edge1,
         start_element,
         sc_types.EDGE_ACCESS_VAR_POS_PERM,
-        ScKeynodes.rrel(1),
+        ScKeynodes.rrel_index(1),
     )
     template.triple(
         set_node,


### PR DESCRIPTION
Role nodes `rrel_1`, `rrel_2`, `rrel_i` are used very often.
So, I added method to ScKeynodes for easy usage:

```python
ScKeynodes.rrel(index: int) -> ScAddr
```

It guarantees valid rrel node.

UPD: max rrel index equal 10 and can be changed